### PR TITLE
Replace gulp-clean, it is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "imports-loader": "^0.6.3",
     "coverjs-loader": "^0.5.0",
     "gulp": "^3.8.8",
-    "gulp-clean": "^0.3.1",
+    "gulp-rimraf": "^0.1.0",
     "gulp-autoprefixer": "^1.0.0",
     "gulp-stylus": "^1.3.2",
     "gulp-eslint": "^0.1.8",


### PR DESCRIPTION
This package is deprecated. There is a warning but the build kinda hides it with all the webpack stuff going on.

https://www.npmjs.org/package/gulp-clean
