### PR TITLE
Add a more complete gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,43 @@
-dist-test
+# --------------------
+# OSX Files
+# --------------------
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+.Spotlight-V100
+.Trashes
+
+# --------------------
+# Sublime Text Files
+# --------------------
+*.sublime-project
+*.sublime-workspace
+
+# --------------------
+# IntelliJ Files
+# --------------------
+*.iml
+*.ipr
+*.iws
+.idea/
+out/
+
+# --------------------
+# Eclipse Files
+# --------------------
+.project
+.metadata
+*.bak
+.classpath
+.settings/
+
+# --------------------
+# App Files
+# --------------------
 node_modules
+coverage
+dist-test
 dist
 frontend-dist


### PR DESCRIPTION
Add a gitignore based off of the [github gitignore](https://github.com/github/gitignore) project. This adds ignores for the 3 most popular IDEs as well as full ignores for all those stupid osx files.

By the way, those gitignores are available via the [github API](https://developer.github.com/v3/gitignore/) so if you really want to make this a seed project you could compile this dynamically.
