### PR TITLE
Use require-dir to pull in tasks automatically

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,22 +1,15 @@
+/*
+  Rather than manage one giant gulpfile, each task has been broken out into its own file in the
+  tasks directory. Any files in that directory get automatically required by the line below.
+  To add a new task, simply add a new task file that directory.
+*/
+
 var
   gulp = require("gulp"),
-  gulpHelp = require("gulp-help");
+  gulpHelp = require("gulp-help"),
+  requireDir = require("require-dir");
 
-var
-  config = require("./project.config"),
-  webpackConfig = require("./webpack.config"),
-  webpackDevConfig = require("./webpack.dev.config"),
-  karmaConfig = require("./karma.config");
+// Update `gulp.task` signature to take task descriptions.
+gulpHelp(gulp);
 
-
-gulpHelp(gulp); // Update `gulp.task` signature to take task descriptions.
-
-require("./tasks/composite")(gulp, config);
-require("./tasks/lint")(gulp, config);
-require("./tasks/frontend/clean")(gulp, config);
-require("./tasks/frontend/copy")(gulp, config);
-require("./tasks/frontend/build-css")(gulp, config);
-require("./tasks/frontend/build-js")(gulp, webpackConfig);
-require("./tasks/frontend/build-js-dev")(gulp, webpackDevConfig);
-require("./tasks/frontend/test-browser")(gulp, config, webpackDevConfig);
-require("./tasks/frontend/test-karma")(gulp, config, karmaConfig);
+requireDir("./tasks", {recurse: true});

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "mocha-loader": "0.7.0",
     "open": "0.0.5",
     "raw-loader": "0.5.1",
+    "require-dir": "^0.1.0",
     "script-loader": "0.6.0",
     "sinon": "1.9.1",
     "sinon-chai": "2.5.0",

--- a/tasks/frontend/build-css.js
+++ b/tasks/frontend/build-css.js
@@ -2,17 +2,19 @@ var
   path = require("path");
 
 var
+  gulp = require("gulp"),
   stylus = require("gulp-stylus"),
   prefix = require("gulp-autoprefixer");
 
-module.exports = function (gulp, config) {
-  gulp.task("build:css", "Build CSS.", function () {
-    return gulp.src(path.join(config.frontendFullPath, config.styles, "*"))
-      .pipe(stylus({
-        set: ["compress"],
-        define: { "ie8": true }
-      }))
-      .pipe(prefix("last 1 version", "> 1%", "ie 8"))
-      .pipe(gulp.dest(path.join(config.destFullPath, "styles")));
-  });
-};
+var
+  config = require("../../project.config");
+
+gulp.task("build:css", "Build CSS.", function () {
+  return gulp.src(path.join(config.frontendFullPath, config.styles, "*"))
+    .pipe(stylus({
+      set: ["compress"],
+      define: { "ie8": true }
+    }))
+    .pipe(prefix("last 1 version", "> 1%", "ie 8"))
+    .pipe(gulp.dest(path.join(config.destFullPath, "styles")));
+});

--- a/tasks/frontend/build-js-dev.js
+++ b/tasks/frontend/build-js-dev.js
@@ -1,21 +1,22 @@
 var
+  gulp = require("gulp"),
   _ = require("lodash"),
   gutil = require("gulp-util"),
   webpack = require("webpack");
 
+var
+  webpackDevConfig = require("../../webpack.dev.config");
 
-module.exports = function (gulp, webpackConfig) {
-  gulp.task("build:js-dev", "Build unminified JS with sourcemaps.", function (callback) {
-    var webpackConf = _.cloneDeep(webpackConfig);
+gulp.task("build:js-dev", "Build unminified JS with sourcemaps.", function (callback) {
+  var webpackConf = _.cloneDeep(webpackDevConfig);
 
-    webpack(webpackConf, function (err, stats) {
-      if (err) {
-        throw new gutil.PluginError("build:js-dev", err);
-      }
-      gutil.log("[build:js-dev]", stats.toString({
-        colors: true
-      }));
-      callback();
-    });
+  webpack(webpackConf, function (err, stats) {
+    if (err) {
+      throw new gutil.PluginError("build:js-dev", err);
+    }
+    gutil.log("[build:js-dev]", stats.toString({
+      colors: true
+    }));
+    callback();
   });
-};
+});

--- a/tasks/frontend/build-js.js
+++ b/tasks/frontend/build-js.js
@@ -1,20 +1,22 @@
 var
+  gulp = require("gulp"),
   _ = require("lodash"),
   gutil = require("gulp-util"),
   webpack = require("webpack");
 
-module.exports = function (gulp, webpackConfig) {
-  gulp.task("build:js", "Build minified JS.", function (callback) {
-    var webpackConf = _.cloneDeep(webpackConfig);
+var
+  webpackConfig = require("../../webpack.config");
 
-    webpack(webpackConf, function (err, stats) {
-      if (err) {
-        throw new gutil.PluginError("build:js", err);
-      }
-      gutil.log("[build:js]", stats.toString({
-        colors: true
-      }));
-      callback();
-    });
+gulp.task("build:js", "Build minified JS.", function (callback) {
+  var webpackConf = _.cloneDeep(webpackConfig);
+
+  webpack(webpackConf, function (err, stats) {
+    if (err) {
+      throw new gutil.PluginError("build:js", err);
+    }
+    gutil.log("[build:js]", stats.toString({
+      colors: true
+    }));
+    callback();
   });
-};
+});

--- a/tasks/frontend/clean.js
+++ b/tasks/frontend/clean.js
@@ -2,12 +2,14 @@ var
   path = require("path");
 
 var
+  gulp = require("gulp"),
   del = require("del");
 
-module.exports = function (gulp, config) {
-  gulp.task("frontend-clean", false, function (cb) {
-    del([
-      path.join(config.dest, "**")
-    ], cb);
-  });
-};
+var
+  config = require("../../project.config");
+
+gulp.task("frontend-clean", false, function (cb) {
+  del([
+    path.join(config.dest, "**")
+  ], cb);
+});

--- a/tasks/frontend/copy.js
+++ b/tasks/frontend/copy.js
@@ -1,11 +1,15 @@
 var
   path = require("path");
 
-module.exports = function (gulp, config) {
-  gulp.task("copy", false, function () {
-    return gulp.src(
-      path.join(config.frontendFullPath, config.assets, "**/*"),
-      { base: path.join(config.frontendFullPath, config.assets) }
-    ).pipe(gulp.dest(config.destFullPath));
-  });
-};
+var
+  gulp = require("gulp");
+
+var
+  config = require("../../project.config");
+
+gulp.task("copy", false, function () {
+  return gulp.src(
+    path.join(config.frontendFullPath, config.assets, "**/*"),
+    { base: path.join(config.frontendFullPath, config.assets) }
+  ).pipe(gulp.dest(config.destFullPath));
+});

--- a/tasks/frontend/test-browser.js
+++ b/tasks/frontend/test-browser.js
@@ -2,38 +2,41 @@ var
   path = require("path");
 
 var
+  gulp = require("gulp"),
   openUrl = require("open"),
   gutil = require("gulp-util"),
   webpack = require("webpack"),
   WebpackDevServer = require("webpack-dev-server");
 
-module.exports = function (gulp, config, webpackConfig) {
-  gulp.task("test", "Run unit tests in the browser.", function () {
-    var server,
-      wpConfig = Object.create(webpackConfig);
+var
+  config = require("../../project.config"),
+  webpackDevConfig = require("../../webpack.dev.config");
 
-    wpConfig.entry = { test: [
-      "webpack/hot/dev-server",
-      "mocha!" + path.join(config.root, config.testRunner)
-    ]};
+gulp.task("test", "Run unit tests in the browser.", function () {
+  var server,
+    wpConfig = Object.create(webpackDevConfig);
 
-    wpConfig.plugins.push(new webpack.HotModuleReplacementPlugin());
+  wpConfig.entry = { test: [
+    "webpack/hot/dev-server",
+    "mocha!" + path.join(config.root, config.testRunner)
+  ]};
 
-    server = new WebpackDevServer(webpack(wpConfig), {
-      hot: true,
-      quiet: false,
-      noInfo: false,
-      watchDelay: 300,
-      publicPath: "/",
-      stats: {
-        colors: true
-      }
-    });
-    server.listen(9890, "localhost", function (err) {
-      if (err) { throw new gutil.PluginError("[webpack-dev-server]", err); }
-      openUrl("http://localhost:9890/webpack-dev-server/test.bundle");
-    });
+  wpConfig.plugins.push(new webpack.HotModuleReplacementPlugin());
 
-    return server;
+  server = new WebpackDevServer(webpack(wpConfig), {
+    hot: true,
+    quiet: false,
+    noInfo: false,
+    watchDelay: 300,
+    publicPath: "/",
+    stats: {
+      colors: true
+    }
   });
-};
+  server.listen(9890, "localhost", function (err) {
+    if (err) { throw new gutil.PluginError("[webpack-dev-server]", err); }
+    openUrl("http://localhost:9890/webpack-dev-server/test.bundle");
+  });
+
+  return server;
+});

--- a/tasks/frontend/test-karma.js
+++ b/tasks/frontend/test-karma.js
@@ -1,80 +1,82 @@
 var
+  gulp = require("gulp"),
   _ = require("lodash"),
   karma = require("karma").server;
 
-module.exports = function (gulp, config, karmaConfig) {
-  gulp.task("test-karma", "Auto-run unit tests in multiple browsers.", function (done) {
-    var karmaConf = _.cloneDeep(karmaConfig);
+var
+  karmaConfig = require("../../karma.config");
 
-    karmaConf.browsers = ["Chrome", "Firefox", "Safari"];
-    karmaConf.singleRun = true;
+gulp.task("test-karma", "Auto-run unit tests in multiple browsers.", function (done) {
+  var karmaConf = _.cloneDeep(karmaConfig);
 
-    karma.start(karmaConf, function (err) {
-      if (err) {
-        done(err);
-        process.exit(1);
-      }
-      done();
-      process.exit(0);
-    });
+  karmaConf.browsers = ["Chrome", "Firefox", "Safari"];
+  karmaConf.singleRun = true;
+
+  karma.start(karmaConf, function (err) {
+    if (err) {
+      done(err);
+      process.exit(1);
+    }
+    done();
+    process.exit(0);
   });
+});
 
-  gulp.task("test-phantom", "Run browser unit tests in the console.", function (done) {
-    var karmaConf = _.cloneDeep(karmaConfig);
+gulp.task("test-phantom", "Run browser unit tests in the console.", function (done) {
+  var karmaConf = _.cloneDeep(karmaConfig);
 
-    karmaConf.browsers = ["PhantomJS"];
-    karmaConf.singleRun = true;
+  karmaConf.browsers = ["PhantomJS"];
+  karmaConf.singleRun = true;
 
-    karma.start(karmaConf, function (err) {
-      if (err) {
-        done(err);
-        process.exit(1);
-      }
-      done();
-      process.exit(0);
-    });
+  karma.start(karmaConf, function (err) {
+    if (err) {
+      done(err);
+      process.exit(1);
+    }
+    done();
+    process.exit(0);
   });
+});
 
-  gulp.task("test-coverage", "Run browser unit tests in the console.", function (done) {
-    var karmaConf = _.cloneDeep(karmaConfig);
+gulp.task("test-coverage", "Run browser unit tests in the console.", function (done) {
+  var karmaConf = _.cloneDeep(karmaConfig);
 
-    karmaConf.webpack.module.postLoaders = [{
-      test: /\.js$/,
-      exclude: /(spec|node_modules)\//,
-      loader: "istanbul-instrumenter"
-    }];
+  karmaConf.webpack.module.postLoaders = [{
+    test: /\.js$/,
+    exclude: /(spec|node_modules)\//,
+    loader: "istanbul-instrumenter"
+  }];
 
-    karmaConf.browsers = ["PhantomJS"];
-    karmaConf.singleRun = true;
-    karmaConf.plugins.push(require("karma-js-coverage"));
-    karmaConf.reporters.push("coverage");
-    karmaConf.coverageReporter = {
-      type: "text"
-    };
+  karmaConf.browsers = ["PhantomJS"];
+  karmaConf.singleRun = true;
+  karmaConf.plugins.push(require("karma-js-coverage"));
+  karmaConf.reporters.push("coverage");
+  karmaConf.coverageReporter = {
+    type: "text"
+  };
 
-    karma.start(karmaConf, function (err) {
-      if (err) {
-        done(err);
-        process.exit(1);
-      }
-      done();
-      process.exit(0);
-    });
+  karma.start(karmaConf, function (err) {
+    if (err) {
+      done(err);
+      process.exit(1);
+    }
+    done();
+    process.exit(0);
   });
+});
 
-  gulp.task("test-watch", "Run browser tests in console; run again on change.", function (done) {
-    var karmaConf = _.cloneDeep(karmaConfig);
+gulp.task("test-watch", "Run browser tests in console; run again on change.", function (done) {
+  var karmaConf = _.cloneDeep(karmaConfig);
 
-    karmaConf.browsers = ["PhantomJS"];
-    karmaConf.singleRun = false;
+  karmaConf.browsers = ["PhantomJS"];
+  karmaConf.singleRun = false;
 
-    karma.start(karmaConf, function (err) {
-      if (err) {
-        done(err);
-        process.exit(1);
-      }
-      done();
-      process.exit(0);
-    });
+  karma.start(karmaConf, function (err) {
+    if (err) {
+      done(err);
+      process.exit(1);
+    }
+    done();
+    process.exit(0);
   });
-};
+});

--- a/tasks/lint.js
+++ b/tasks/lint.js
@@ -2,36 +2,37 @@ var
   path = require("path");
 
 var
+  gulp = require("gulp"),
   _ = require("lodash"),
   gutil = require("gulp-util"),
   map = require("map-stream"),
   eslint = require("gulp-eslint");
 
+var
+  config = require("../project.config");
 
-module.exports = function (gulp, config) {
-  gulp.task("lint", "Lint application- and test-code.", function (cb) {
-    var success = true;
+gulp.task("lint", "Lint application- and test-code.", function (cb) {
+  var success = true;
 
-    gulp.src([
-      path.join(config.frontendFullPath, "**/*.js"),
-      path.join(config.root, "*.js"),
-      path.join(config.root, "tasks/**/*.js")
-    ])
-      .pipe(eslint())
-      .pipe(map(function (file, output) {
-        success = success && _.every(file.eslint && file.eslint.messages, function (message) {
-          return message.severity !== 2;
-        });
-        return output(null, file);
-      }))
-      .pipe(eslint.format())
-      .on("end", function () {
-        if (success) {
-          gutil.log("[lint]", "SUCCESS!");
-          cb();
-        } else {
-          cb(new gutil.PluginError("lint", "*** FAILED ESLINT ***"));
-        }
+  gulp.src([
+    path.join(config.frontendFullPath, "**/*.js"),
+    path.join(config.root, "*.js"),
+    path.join(config.root, "tasks/**/*.js")
+  ])
+    .pipe(eslint())
+    .pipe(map(function (file, output) {
+      success = success && _.every(file.eslint && file.eslint.messages, function (message) {
+        return message.severity !== 2;
       });
-  });
-};
+      return output(null, file);
+    }))
+    .pipe(eslint.format())
+    .on("end", function () {
+      if (success) {
+        gutil.log("[lint]", "SUCCESS!");
+        cb();
+      } else {
+        cb(new gutil.PluginError("lint", "*** FAILED ESLINT ***"));
+      }
+    });
+});


### PR DESCRIPTION
Addresses #7 

This PR aligns the project with the "blessed" way to require tasks as per the Gulp project. Two things had to happen for this to work:
1. Use `require-dir` to auto require any task placed under tasks.
2. Removes the export syntax from the task files. 

NOTE: This PR is best viewed without whitespace changes. Use the query param `?w=1` to do that.
