### PR TITLE
Extract gulp help into it's own task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,15 +1,8 @@
 var
-  gulp = require("gulp"),
-  gulpHelp = require("gulp-help");
-
-var
   config = require("./project.config"),
   webpackConfig = require("./webpack.config"),
   webpackDevConfig = require("./webpack.dev.config"),
   karmaConfig = require("./karma.config");
-
-
-gulpHelp(gulp); // Update `gulp.task` signature to take task descriptions.
 
 require("./tasks/composite")(gulp, config);
 require("./tasks/lint")(gulp, config);

--- a/tasks/help.js
+++ b/tasks/help.js
@@ -1,0 +1,6 @@
+var
+  gulp = require("gulp"),
+  gulpHelp = require("gulp-help");
+
+// Update `gulp.task` signature to take task descriptions.
+gulpHelp(gulp);


### PR DESCRIPTION
Now that the `gulpfile` has been pared down to be just includes, the help task doesn't really fit in there anymore. Rally, even though the help task is only a single line for now it could easily grow as testing docs are added.
