### PR TITLE
Add license to the project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Dale Bustad <dale@divmain.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -93,3 +93,9 @@ Available tasks
 | frontend/test-runner.js | Configures and executes tests.                                  |
 | frontend-dist/          | Builds are generated here.                                      |
 | tasks/                  | Component gulp tasks                                            |
+
+***
+
+## License
+
+[MIT License](http://opensource.org/licenses/MIT)

--- a/start.sh
+++ b/start.sh
@@ -43,6 +43,7 @@ echo -n "cleaning up... "
 
 rm -f $CURRENTDIR/start.sh
 rm -f $CURRENTDIR/README.md
+rm -f $CURRENTDIR/LICENSE
 rm -rf $CURRENTDIR/.git
 echo "OK"
 


### PR DESCRIPTION
I think buried in GitHub's TOS there is something about an implied open source license if left unspecified for private repos but in reality the [default license](http://programmers.stackexchange.com/questions/26548/what-is-the-default-software-license) is no license which is bad news bears. Open this up and make it MIT
