### PR TITLE
Document the .eslintrc file

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,139 +1,190 @@
 {
   "rules": {
-    "no-cond-assign": 2,
-    "no-console": 2,
-    "no-constant-condition": 2,
-    "no-comma-dangle": 1,
-    "no-control-regex": 2,
-    "no-debugger": 2,
-    "no-dupe-keys": 2,
-    "no-empty": 2,
-    "no-empty-class": 2,
-    "no-ex-assign": 2,
-    "no-extra-boolean-cast": 2,
-    "no-extra-parens": 2,
-    "no-extra-semi": 2,
-    "no-func-assign": 2,
-    "no-inner-declarations": 1,
-    "no-invalid-regexp": 2,
-    "no-negated-in-lhs": 2,
-    "no-obj-calls": 2,
-    "no-regex-spaces": 1,
-    "no-reserved-keys": 1,
-    "no-sparse-arrays": 2,
-    "no-unreachable": 2,
-    "use-isnan": 2,
-    "valid-jsdoc": [1, {
+    // Possible Errors
+    // The following rules point out areas where you might have made mistakes.
+
+    "no-comma-dangle": 1,         // disallow trailing commas in object literals
+    "no-cond-assign": 2,          // disallow assignment in conditional expressions
+    "no-console": 2,              // disallow use of console (off by default in the node environment)
+    "no-constant-condition": 2,   // disallow use of constant expressions in conditions
+    "no-control-regex": 2,        // disallow control characters in regular expressions
+    "no-debugger": 2,             // disallow use of debugger
+    "no-dupe-keys": 2,            // disallow duplicate keys when creating object literals
+    "no-empty": 2,                // disallow empty statements
+    "no-empty-class": 2,          // disallow the use of empty character classes in regular expressions
+    "no-ex-assign": 2,            // disallow assigning to the exception in a catch block
+    "no-extra-boolean-cast": 2,   // disallow double-negation boolean casts in a boolean context
+    "no-extra-parens": 2,         // disallow unnecessary parentheses (off by default)
+    "no-extra-semi": 2,           // disallow unnecessary semicolons
+    "no-func-assign": 2,          // disallow overwriting functions written as function declarations
+    "no-inner-declarations": 1,   // disallow function or variable declarations in nested blocks
+    "no-invalid-regexp": 2,       // disallow invalid regular expression strings in the RegExp constructor
+    "no-irregular-whitespace": 2, // disallow irregular whitespace outside of strings and comments
+    "no-negated-in-lhs": 2,       // disallow negation of the left operand of an in expression
+    "no-obj-calls": 2,            // disallow the use of object properties of the global object (Math and JSON) as functions
+    "no-regex-spaces": 1,         // disallow multiple spaces in a regular expression literal
+    "no-reserved-keys": 1,        // disallow reserved words being used as object literal keys (off by default)
+    "no-sparse-arrays": 2,        // disallow sparse arrays
+    "no-unreachable": 2,          // disallow unreachable statements after a return, throw, continue, or break statement
+    "use-isnan": 2,               // disallow comparisons with the value NaN
+    "valid-typeof": 2,            // Ensure that the results of typeof are compared against a valid string
+    "valid-jsdoc": [1, {          // Ensure JSDoc comments are valid (off by default)
       "prefer": {
         "return": "returns"
       },
       "requireReturn": false
     }],
-    "valid-typeof": 2,
-    "block-scoped-var": 1,
-    "complexity": [1, 250],
-    "consistent-return": 0,
-    "curly": 2,
-    "default-case": 2,
-    "dot-notation": 1,
-    "eqeqeq": 2,
-    "guard-for-in": 1,
-    "no-alert": 2,
-    "no-caller": 2,
-    "no-div-regex": 1,
-    "no-else-return": 1,
-    "no-empty-label": 2,
-    "no-eq-null": 2,
-    "no-eval": 2,
-    "no-extend-native": 2,
-    "no-extra-bind": 2,
-    "no-fallthrough": 2,
-    "no-floating-decimal": 2,
-    "no-implied-eval": 2,
-    "no-labels": 2,
-    "no-iterator": 2,
-    "no-lone-blocks": 2,
-    "no-loop-func": 0,
-    "no-multi-str": 0,
-    "no-native-reassign": 2,
-    "no-new": 2,
-    "no-new-func": 2,
-    "no-new-wrappers": 2,
-    "no-octal": 2,
-    "no-octal-escape": 2,
-    "no-proto": 2,
-    "no-redeclare": 1,
-    "no-return-assign": 0,
-    "no-script-url": 2,
-    "no-self-compare": 2,
-    "no-sequences": 2,
-    "no-unused-expressions": 0,
-    "no-void": 2,
-    "no-warning-comments": 0,
-    "no-with": 2,
-    "radix": 2,
-    "vars-on-top": 1,
-    "wrap-iife": [2, "inside"],
-    "yoda": "never",
-    "global-strict": [2, "never"],
-    "no-extra-strict": 2,
-    "strict": 0,
-    "no-catch-shadow": 2,
-    "no-delete-var": 2,
-    "no-label-var": 2,
-    "no-shadow": 1,
-    "no-shadow-restricted-names": 2,
-    "no-undef": 2,
-    "no-undefined": 2,
-    "no-undef-init": 2,
-    "no-unused-vars": 1,
-    "no-use-before-define": 2,
-    "handle-callback-err": 0,
-    "no-mixed-requires": [1, true],
-    "no-new-require": 2,
-    "no-path-concat": 2,
-    "no-process-exit": 0,
-    "no-restricted-modules": 0,
-    "no-sync": 0,
-    "brace-style": [2, "1tbs", { "allowSingleLine": true }],
-    "camelcase": 2,
-    "consistent-this": [2, "self"],
-    "eol-last": 2,
-    "func-names": 0,
-    "func-style": 0,
-    "new-cap": 2,
-    "new-parens": 2,
-    "no-nested-ternary": 2,
-    "no-array-constructor": 2,
-    "no-lonely-if": 0,
-    "no-new-object": 1,
-    "no-spaced-func": 2,
-    "no-space-before-semi": 2,
-    "no-ternary": 0,
-    "no-trailing-spaces": 2,
-    "no-underscore-dangle": 0,
-    "no-wrap-func": 2,
-    "no-mixed-spaces-and-tabs": 2,
-    "quotes": [1, "double", "avoid-escape"],
-    "quote-props": 0,
-    "semi": [2, "always"],
-    "sort-vars": 0,
-    "space-after-keywords": "always",
-    "space-in-brackets": 0,
-    "space-in-parens": 0,
-    "space-infix-ops": 2,
-    "space-return-throw-case": 2,
-    "space-unary-word-ops": 2,
-    "max-nested-callbacks": [2, 4],
-    "one-var": 0,
-    "wrap-regex": 0,
-    "max-depth": 0,
-    "max-len": [2, 100, 4],
-    "max-params": [1, 3],
-    "max-statements": 0,
-    "no-bitwise": 0,
-    "no-plusplus": 0
+
+    // Best Practices
+    // These are rules designed to prevent you from making mistakes. They either prescribe a better way of doing something or help you avoid footguns.
+
+    "block-scoped-var": 1,       // treat var statements as if they were block scoped (off by default)
+    "complexity": [1, 250],      // specify the maximum cyclomatic complexity allowed in a program (off by default)
+    "consistent-return": 0,      // require return statements to either always or never specify values
+    "curly": 2,                  // specify curly brace conventions for all control statements
+    "default-case": 2,           // require default case in switch statements (off by default)
+    "dot-notation": 1,           // encourages use of dot notation whenever possible
+    "eqeqeq": 2,                 // require the use of === and !==
+    "guard-for-in": 1,           // make sure for-in loops have an if statement (off by default)
+    "no-alert": 2,               // disallow the use of alert, confirm, and prompt
+    "no-caller": 2,              // disallow use of arguments.caller or arguments.callee
+    "no-div-regex": 1,           // disallow division operators explicitly at beginning of regular expression (off by default)
+    "no-else-return": 1,         // disallow else after a return in an if (off by default)
+    "no-empty-label": 2,         // disallow use of labels for anything other then loops and switches
+    "no-eq-null": 2,             // disallow comparisons to null without a type-checking operator (off by default)
+    "no-eval": 2,                // disallow use of eval()
+    "no-extend-native": 2,       // disallow adding to native types
+    "no-extra-bind": 2,          // disallow unnecessary function binding
+    "no-fallthrough": 2,         // disallow fallthrough of case statements
+    "no-floating-decimal": 2,    // disallow the use of leading or trailing decimal points in numeric literals (off by default)
+    "no-implied-eval": 2,        // disallow use of eval()-like methods
+    "no-iterator": 2,            // disallow usage of __iterator__ property
+    "no-labels": 2,              // disallow use of labeled statements
+    "no-lone-blocks": 2,         // disallow unnecessary nested blocks
+    "no-loop-func": 0,           // disallow creation of functions within loops
+    "no-multi-spaces": 0,        // disallow use of multiple spaces
+    "no-multi-str": 2,           // disallow use of multiline strings
+    "no-native-reassign": 2,     // disallow reassignments of native objects
+    "no-new": 2,                 // disallow use of new operator when not part of the assignment or comparison
+    "no-new-func": 2,            // disallow use of new operator for Function object
+    "no-new-wrappers": 2,        // disallows creating new instances of String,Number, and Boolean
+    "no-octal": 2,               // disallow use of octal literals
+    "no-octal-escape": 2,        // disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
+    "no-process-env": 2,         // disallow use of process.env (off by default)
+    "no-proto": 2,               // disallow usage of __proto__ property
+    "no-redeclare": 1,           // disallow declaring the same variable more then once
+    "no-return-assign": 0,       // disallow use of assignment in return statement
+    "no-script-url": 2,          // disallow use of javascript: urls.
+    "no-self-compare": 2,        // disallow comparisons where both sides are exactly the same (off by default)
+    "no-sequences": 2,           // disallow use of comma operator
+    "no-unused-expressions": 0,  // disallow usage of expressions in statement position
+    "no-void": 2,                // disallow use of void operator (off by default)
+    "no-warning-comments": 0,    // disallow usage of configurable warning terms in comments - e.g. TODO or FIXME (off by default)
+    "no-with": 2,                // disallow use of the with statement
+    "radix": 2,                  // require use of the second argument for parseInt() (off by default)
+    "vars-on-top": 1,            // requires to declare all vars on top of their containing scope (off by default)
+    "wrap-iife": [2, "inside"],  // require immediate function invocation to be wrapped in parentheses (off by default)
+    "yoda": "never",             // require or disallow Yoda conditions
+
+    // Strict Mode
+    // These rules relate to using strict mode.
+
+    "global-strict": [           // require or disallow the "use strict" pragma in the global scope (off by default in the node environment)
+      2, "never"
+    ],
+    "no-extra-strict": 2,        // disallow unnecessary use of "use strict"; when already in strict mode
+    "strict": 0,                 // require that all functions are run in strict mode
+
+    // Variables
+    // These rules have to do with variable declarations.
+
+    "no-catch-shadow": 2,        // disallow the catch clause parameter name being the same as a variable in the outer scope (off by default in the node environment)
+    "no-delete-var": 2,          // disallow deletion of variables
+    "no-label-var": 2,           // disallow labels that share a name with a variable
+    "no-shadow": 1,              // disallow declaration of variables already declared in the outer scope
+    "no-shadow-restricted-names": 2, // disallow shadowing of names such as arguments
+    "no-undef": 2,               // disallow use of undeclared variables unless mentioned in a /*global */ block
+    "no-undef-init": 2,          // disallow use of undefined when initializing variables
+    "no-undefined": 2,           // disallow use of undefined variable (off by default)
+    "no-unused-vars": 1,         // disallow declaration of variables that are not used in the code
+    "no-use-before-define": 2,   // disallow use of variables before they are defined
+
+    // Node.js
+    // These rules are specific to JavaScript running on Node.js.
+
+    "handle-callback-err": 0,    // enforces error handling in callbacks (off by default) (on by default in the node environment)
+    "no-mixed-requires": [       // disallow mixing regular variable and require declarations (off by default) (on by default in the node environment)
+      1, true
+    ],
+    "no-new-require": 2,         // disallow use of new operator with the require function (off by default) (on by default in the node environment)
+    "no-path-concat": 2,         // disallow string concatenation with __dirname and __filename (off by default) (on by default in the node environment)
+    "no-process-exit": 0,        // disallow process.exit() (on by default in the node environment)
+    "no-restricted-modules": 0,  // restrict usage of specified node modules (off by default)
+    "no-sync": 0,                // disallow use of synchronous methods (off by default)
+
+    // Stylistic Issues
+    // These rules are purely matters of style and are quite subjective.
+
+    "brace-style": [             // enforce one true brace style (off by default)
+      2, "1tbs", { "allowSingleLine": true }
+    ],
+    "camelcase": 2,              // require camel case names
+    "comma-spacing": 2,          // enforce spacing before and after comma
+    "comma-style": 2,            // enforce one true comma style (off by default)
+    "consistent-this": [         // enforces consistent naming when capturing the current execution context (off by default)
+      2, "self"
+    ],
+    "eol-last": 2,               // enforce newline at the end of file, with no multiple empty lines
+    "func-names": 0,             // require function expressions to have a name (off by default)
+    "func-style": 0,             // enforces use of function declarations or expressions (off by default)
+    "key-spacing": 2,            // enforces spacing between keys and values in object literal properties
+    "max-nested-callbacks": [    // specify the maximum depth callbacks can be nested (off by default)
+      2, 4
+    ],
+    "new-cap": 2,                // require a capital letter for constructors
+    "new-parens": 2,             // disallow the omission of parentheses when invoking a constructor with no arguments
+    "no-array-constructor": 2,   // disallow use of the Array constructor
+    "no-lonely-if": 0,           // disallow if as the only statement in an else block (off by default)
+    "no-mixed-spaces-and-tabs": 2, // disallow mixed spaces and tabs for indentation
+    "no-nested-ternary": 2,      // disallow nested ternary expressions (off by default)
+    "no-new-object": 1,          // disallow use of the Object constructor
+    "no-space-before-semi": 2,   // disallow space before semicolon
+    "no-spaced-func": 2,         // disallow space between function identifier and application
+    "no-ternary": 0,             // disallow the use of ternary operators (off by default)
+
+    "no-trailing-spaces": 2,     // disallow trailing whitespace at the end of lines
+    "no-multiple-empty-lines": 2, // disallow multiple empty lines (off by default)
+    "no-underscore-dangle": 0,   // disallow dangling underscores in identifiers
+    "no-wrap-func": 2,           // disallow wrapping of non-IIFE statements in parens
+    "one-var": 0,                // allow just one var statement per function (off by default)
+    "padded-blocks": 0,          // enforce padding within blocks (off by default)
+    "quotes": [                  // specify whether double or single quotes should be used
+      1, "double", "avoid-escape"
+    ],
+    "quote-props": 0,            // require quotes around object literal property names (off by default)
+    "semi": [2, "always"],       // require or disallow use of semicolons instead of ASI
+    "sort-vars": 0,              // sort variables within the same declaration block (off by default)
+    "space-after-keywords": "always", // require a space after certain keywords (off by default)
+    "space-before-blocks": 2,    // require or disallow space before blocks (off by default)
+    "space-in-brackets": 0,      // require or disallow spaces inside brackets (off by default)
+    "space-in-parens": 0,        // require or disallow spaces inside parentheses (off by default)
+    "space-infix-ops": 2,        // require spaces around operators
+    "space-return-throw-case": 2, // require a space after return, throw, and case
+    "space-unary-word-ops": 2,   // require a space around word operators such as typeof (off by default)
+    "spaced-line-comment": 2,    // require or disallow a space immediately following the // in a line comment (off by default)
+    "wrap-regex": 0,             // require regex literals to be wrapped in parentheses (off by default)
+
+    // Legacy
+    // The following rules are included for compatibility with JSHint and JSLint. While the names of the rules may not match up with the JSHint/JSLint counterpart, the functionality is the same.
+
+    "max-depth": 0,              // specify the maximum depth that blocks can be nested (off by default)
+    "max-len": [2, 100, 4],      // specify the maximum length of a line in your program (off by default)
+    "max-params": [1, 3],        // limits the number of parameters that can be used in the function declaration. (off by default)
+    "max-statements": 0,         // specify the maximum number of statement allowed in a function (off by default)
+    "no-bitwise": 0,             // disallow use of bitwise operators (off by default)
+    "no-plusplus": 0             // disallow use of unary operators, ++ and -- (off by default)
   },
+
   "globals": {
     "require": true,
     "describe": true,
@@ -145,9 +196,12 @@
     "sinon": true,
     "expect": true
   },
+
   "env":{
     "browser": true,
     "node": true,
-    "mocha": true
+    "amd": false,
+    "mocha": true,
+    "jasmine": false
   }
 }


### PR DESCRIPTION
Most people are much more familiar with jsHint than eslint, myself included. When I wanted to see what was enforced for this project and first saw the wall of config that is the `.eslintrc` file I felt pretty out of my depth. 

In an effort to make this a little more approachable I've decided to use a little regex magic to document the `.eslintrc` file in the same way that [jsHint](https://github.com/jshint/jshint/blob/master/examples/.jshintrc) does. You has already done most of the hard work by copying the master rules list so this PR just adds a little documentation straight off of the [rules page](http://eslint.org/docs/rules/). Your rules should still be in place and should still warn at the appropriate levels.
