### PR TITLE
Clean directory contents without removing the directory

### DIFF
--- a/tasks/frontend/clean.js
+++ b/tasks/frontend/clean.js
@@ -10,6 +10,6 @@ var
 
 gulp.task("frontend-clean", false, function (cb) {
   del([
-    path.join(config.dest, "**")
+    path.join(config.dest, "/**/*")
   ], cb);
 });


### PR DESCRIPTION
People need to be able to run servers in the dist directory so that files hosted on CDNs will be loaded. If you remove the whole directory you need to cd back to somewhere valid and then cd back in with every build.
