### PR TITLE
Update test-runner.js

### DIFF
--- a/frontend/test-runner.js
+++ b/frontend/test-runner.js
@@ -41,6 +41,6 @@ window.chai.use(require("sinon-chai"));
  * Requires in all spec files.  See above comment.
  */
 
-_.each(_.keys(specFileRequire), function (specFileName) {
+_.each(specFileRequire.keys(), function (specFileName) {
   specFileRequire(specFileName);
 });


### PR DESCRIPTION
`require.context` returns a function with a `keys` function property.

As is, running `gulp test` errors out on me with errors like: Uncaught Error: Cannot find module 'keys'.
